### PR TITLE
iOS 번들 ID와 서명 설정 정비 (#48)

### DIFF
--- a/ios/wear_again.xcodeproj/project.pbxproj
+++ b/ios/wear_again.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		4CB389BA2EB10031004DF311 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4CB389B92EB10031004DF311 /* Config.xcconfig */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		CDCC1798127D8C573446606D /* libPods-wear_again.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BEB5685D8A89B794F8D89CE /* libPods-wear_again.a */; };
+		A17BEF8EF0E20ED5267DC918 /* libPods-wear_again.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F1D39A8CFB28EB30E938AF4 /* libPods-wear_again.a */; };
 		D4D705D3F4A19AE246F77C8F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
@@ -20,12 +20,12 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = wear_again/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = wear_again/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = wear_again/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		1E32CB1A783C05EE213A09D2 /* Pods-wear_again.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-wear_again.release.xcconfig"; path = "Target Support Files/Pods-wear_again/Pods-wear_again.release.xcconfig"; sourceTree = "<group>"; };
+		1F1D39A8CFB28EB30E938AF4 /* libPods-wear_again.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-wear_again.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C7FE2D12EAE1457007AA95C /* wear_again-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wear_again-Bridging-Header.h"; sourceTree = "<group>"; };
 		4CB389B92EB10031004DF311 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
-		4D06A30AC553B645C900B83F /* Pods-wear_again.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-wear_again.release.xcconfig"; path = "Target Support Files/Pods-wear_again/Pods-wear_again.release.xcconfig"; sourceTree = "<group>"; };
-		5BEB5685D8A89B794F8D89CE /* libPods-wear_again.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-wear_again.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		70EFE5DE916E920758EC9A81 /* Pods-wear_again.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-wear_again.debug.xcconfig"; path = "Target Support Files/Pods-wear_again/Pods-wear_again.debug.xcconfig"; sourceTree = "<group>"; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = wear_again/AppDelegate.swift; sourceTree = "<group>"; };
+		788C062CB9BB6DBE514B3D53 /* Pods-wear_again.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-wear_again.debug.xcconfig"; path = "Target Support Files/Pods-wear_again/Pods-wear_again.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = wear_again/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8FDD5C05B27A4BEE944AF0FA /* README.md */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = README.md; path = ../assets/fonts/README.md; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -36,7 +36,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CDCC1798127D8C573446606D /* libPods-wear_again.a in Frameworks */,
+				A17BEF8EF0E20ED5267DC918 /* libPods-wear_again.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -60,7 +60,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				5BEB5685D8A89B794F8D89CE /* libPods-wear_again.a */,
+				1F1D39A8CFB28EB30E938AF4 /* libPods-wear_again.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -107,8 +107,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				70EFE5DE916E920758EC9A81 /* Pods-wear_again.debug.xcconfig */,
-				4D06A30AC553B645C900B83F /* Pods-wear_again.release.xcconfig */,
+				788C062CB9BB6DBE514B3D53 /* Pods-wear_again.debug.xcconfig */,
+				1E32CB1A783C05EE213A09D2 /* Pods-wear_again.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -120,13 +120,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "wear_again" */;
 			buildPhases = (
-				B79C9E6EDBD6A255E48B8A31 /* [CP] Check Pods Manifest.lock */,
+				19FD85766F7DCBD8F8B1F9C5 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				D2E271BD8738E90AF9853D81 /* [CP] Embed Pods Frameworks */,
-				B23A12672B8213D547478AAE /* [CP] Copy Pods Resources */,
+				D9A9A8FC430EE8061E11407C /* [CP] Embed Pods Frameworks */,
+				305AA41D9FD6624B1C6DCD7A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -199,24 +199,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		B23A12672B8213D547478AAE /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-wear_again/Pods-wear_again-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-wear_again/Pods-wear_again-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-wear_again/Pods-wear_again-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B79C9E6EDBD6A255E48B8A31 /* [CP] Check Pods Manifest.lock */ = {
+		19FD85766F7DCBD8F8B1F9C5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -238,7 +221,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D2E271BD8738E90AF9853D81 /* [CP] Embed Pods Frameworks */ = {
+		305AA41D9FD6624B1C6DCD7A /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-wear_again/Pods-wear_again-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-wear_again/Pods-wear_again-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-wear_again/Pods-wear_again-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D9A9A8FC430EE8061E11407C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -271,12 +271,14 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 70EFE5DE916E920758EC9A81 /* Pods-wear_again.debug.xcconfig */;
+			baseConfigurationReference = 788C062CB9BB6DBE514B3D53 /* Pods-wear_again.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = S9TP28K2B4;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2BZQKM9692;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -379,8 +381,10 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ssasinsa.yoosang;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "org.reactjs.native.example.wear-again";
 				PRODUCT_NAME = wear_again;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = WearAgainDev;
 				SWIFT_OBJC_BRIDGING_HEADER = "wear_again-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -390,12 +394,14 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D06A30AC553B645C900B83F /* Pods-wear_again.release.xcconfig */;
+			baseConfigurationReference = 1E32CB1A783C05EE213A09D2 /* Pods-wear_again.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = S9TP28K2B4;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2BZQKM9692;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.framework/Headers\"",
@@ -497,8 +503,10 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ssasinsa.yoosang;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "org.reactjs.native.example.wear-again";
 				PRODUCT_NAME = wear_again;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = WearAgainDev;
 				SWIFT_OBJC_BRIDGING_HEADER = "wear_again-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
### 🔧 작업 내용
- iOS Debug/Release 타겟을 Manual 코드 서명으로 전환하고 디바이스 빌드를 Team ID 2BZQKM9692 기준으로 정리했습니다.
- 실기기 배포용 번들 식별자를 `org.reactjs.native.example.wear-again`으로 갱신하고 WearAgainDev 프로비저닝 프로파일을 지정했습니다.
- CocoaPods 빌드 단계가 최신 생성된 `libPods-wear_again.a`와 지원 스크립트를 참조하도록 재정렬했습니다.

### ✅ 테스트
- 테스트 미실행 (iOS 프로젝트 설정 변경만 포함)

### 🔗 관련 이슈
- Closes #48