### PR TITLE
신청 내역 API 연동 (#60)

### DIFF
--- a/src/api/events/applications.ts
+++ b/src/api/events/applications.ts
@@ -1,0 +1,71 @@
+import {apiClient} from '../client';
+
+export type ApplicationListParams = {
+  status?: string;
+  from?: string;
+  to?: string;
+  cursor?: string;
+  limit?: number;
+};
+
+export type ApplicationSummaryResponse = {
+  applicationId: string;
+  eventId: string;
+  eventTitle: string;
+  thumbnailUrl?: string | null;
+  description: string;
+  location: string;
+  address?: string | null;
+  eventPeriod: {
+    startDate: string;
+    endDate: string;
+  };
+  eventStatus: string;
+  applicationStatus?: string;
+};
+
+export type ApplicationDetailResponse = ApplicationSummaryResponse & {
+  usageGuide?: string | string[];
+  precautions?: string | string[];
+  optionTrail?: Array<{
+    eventOptionId: number;
+    name: string;
+    type: string;
+  }>;
+};
+
+export type ApplicationListResult = {
+  items: ApplicationSummaryResponse[];
+  nextCursor?: string | null;
+  hasNext: boolean;
+};
+
+export type ApplicationQrResponse = {
+  qrToken: string;
+  expiresIn: number;
+};
+
+const BASE_PATH = '/events/applications';
+
+export const applicationsApi = {
+  async getApplications(params: ApplicationListParams = {}) {
+    const {data} = await apiClient.get<ApplicationListResult>(BASE_PATH, {
+      params,
+    });
+    return data;
+  },
+
+  async getApplicationDetail(applicationId: string) {
+    const {data} = await apiClient.get<ApplicationDetailResponse>(
+      `${BASE_PATH}/${applicationId}`,
+    );
+    return data;
+  },
+
+  async issueApplicationQr(applicationId: string) {
+    const {data} = await apiClient.post<ApplicationQrResponse>(
+      `${BASE_PATH}/${applicationId}/qr`,
+    );
+    return data;
+  },
+};

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,11 +5,13 @@
 
 import React from 'react';
 import RootNavigation from './navigation/RootNavigation';
-
+import {QueryClientProvider} from './providers/QueryClientProvider';
 
 function App() {
   return (
+    <QueryClientProvider>
       <RootNavigation />
+    </QueryClientProvider>
   );
 }
 

--- a/src/app/navigation/types.ts
+++ b/src/app/navigation/types.ts
@@ -1,8 +1,9 @@
-import {ApplicationHistory} from '../screens/applications/types';
+import {ApplicationSummary} from '../screens/applications/types';
 
 export type ApplicationsStackParamList = {
   ApplicationList: undefined;
   ApplicationDetail: {
-    application: ApplicationHistory;
+    applicationId: string;
+    initialData?: ApplicationSummary;
   };
 };

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -1,0 +1,220 @@
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+} from '@tanstack/react-query';
+import {applicationsApi} from '../api/events/applications';
+import {
+  ApplicationDetail,
+  ApplicationOption,
+  ApplicationStatusLabel,
+  ApplicationSummary,
+} from '../screens/applications/types';
+import React from 'react';
+import {Alert} from 'react-native';
+
+function mapStatus(status?: string): ApplicationStatusLabel {
+  switch (status) {
+    case 'UPCOMING':
+    case 'SCHEDULED':
+    case 'OPENING':
+      return '예정';
+    case 'OPEN':
+    case 'RUNNING':
+      return '진행중';
+    case 'CLOSED':
+    case 'FINISHED':
+    case 'ENDED':
+      return '종료';
+    default:
+      return '진행중';
+  }
+}
+
+function normalizeText(value?: string | string[]): string[] {
+  if (!value) {
+    return [];
+  }
+
+  const sanitize = (input?: string | null) => {
+    if (!input) {
+      return '';
+    }
+    return input
+      .replace(/<\/?(p|div)>/gi, '\n')
+      .replace(/<\/?(ul|ol)>/gi, '\n')
+      .replace(/<\/?li>/gi, '\n')
+      .replace(/<br\s*\/?\s*>/gi, '\n')
+      .replace(/\r\n/g, '\n')
+      .replace(/\\n/g, '\n')
+      .replace(/[•·]/g, '\n')
+      .replace(/<[^>]+>/g, ' ');
+  };
+
+  const toList = (input: string | string[]): string[] => {
+    if (Array.isArray(input)) {
+      return input;
+    }
+
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((item): item is string => typeof item === 'string');
+      }
+    } catch (error) {
+      // ignore json parsing failures and fall back to plain text parsing
+    }
+
+    return sanitize(trimmed).split('\n');
+  };
+
+  return toList(value)
+    .map(item => sanitize(item))
+    .flatMap(item => item.split('\n'))
+    .map(line => line.replace(/^[\-–—·•\d\.\)\s]+/, '').trim())
+    .filter(Boolean);
+}
+
+function mapOptionTrail(
+  trail: applicationsApi.ApplicationDetailResponse['optionTrail'],
+): ApplicationOption[] {
+  if (!Array.isArray(trail)) {
+    return [];
+  }
+  return trail.map(option => ({
+    eventOptionId: option.eventOptionId,
+    name: option.name,
+    type: option.type,
+  }));
+}
+
+function toSummary(
+  item: applicationsApi.ApplicationSummaryResponse,
+): ApplicationSummary {
+  return {
+    id: String(item.applicationId),
+    eventId: String(item.eventId),
+    title: item.eventTitle,
+    description: item.description,
+    status: mapStatus(item.eventStatus ?? item.applicationStatus),
+    startDate: item.eventPeriod.startDate,
+    endDate: item.eventPeriod.endDate,
+    location: item.location,
+    address: item.address ?? undefined,
+    thumbnailUrl: item.thumbnailUrl ?? undefined,
+  };
+}
+
+function toDetail(
+  payload: applicationsApi.ApplicationDetailResponse,
+): ApplicationDetail {
+  const base = toSummary(payload);
+  return {
+    ...base,
+    usageGuide: normalizeText(payload.usageGuide),
+    precautions: normalizeText(payload.precautions),
+    optionTrail: mapOptionTrail(payload.optionTrail),
+  };
+}
+
+export function useApplicationsList() {
+  return useInfiniteQuery({
+    queryKey: ['applications', 'list'],
+    queryFn: ({pageParam}) =>
+      applicationsApi.getApplications({cursor: pageParam ?? undefined}),
+    getNextPageParam: lastPage =>
+      lastPage.hasNext ? lastPage.nextCursor ?? undefined : undefined,
+    select: data => ({
+      ...data,
+      pages: data.pages.map(page => ({
+        ...page,
+        items: page.items.map(toSummary),
+      })),
+    }),
+  });
+}
+
+export function useApplicationDetail(
+  applicationId: string,
+  initialData?: ApplicationSummary,
+) {
+  return useQuery({
+    queryKey: ['applications', 'detail', applicationId],
+    queryFn: async () => {
+      const detail = await applicationsApi.getApplicationDetail(applicationId);
+      return toDetail(detail);
+    },
+    placeholderData: initialData
+      ? toDetail({
+          ...initialData,
+          eventPeriod: {
+            startDate: initialData.startDate,
+            endDate: initialData.endDate,
+          },
+        } as applicationsApi.ApplicationDetailResponse)
+      : undefined,
+  });
+}
+
+export function useApplicationQr(applicationId: string) {
+  const [qrToken, setQrToken] = React.useState<string | null>(null);
+  const [secondsLeft, setSecondsLeft] = React.useState<number>(0);
+
+  const {mutate, isPending} = useMutation({
+    mutationFn: () => applicationsApi.issueApplicationQr(applicationId),
+    onSuccess: data => {
+      setQrToken(data.qrToken);
+      setSecondsLeft(data.expiresIn);
+    },
+    onError: () => {
+      Alert.alert(
+        'QR 발급 실패',
+        'QR을 발급하지 못했습니다. 잠시 후 다시 시도해주세요.',
+      );
+    },
+  });
+
+  React.useEffect(() => {
+    if (!secondsLeft) {
+      return;
+    }
+    const timer = setInterval(() => {
+      setSecondsLeft(prev => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [secondsLeft]);
+
+  const reissue = React.useCallback(() => {
+    if (!applicationId || isPending) {
+      return;
+    }
+    mutate();
+  }, [applicationId, isPending, mutate]);
+
+  React.useEffect(() => {
+    if (!applicationId) {
+      return;
+    }
+    mutate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [applicationId]);
+
+  return {
+    qrToken,
+    secondsLeft,
+    isIssuing: isPending,
+    isExpired: !!qrToken && secondsLeft <= 0,
+    reissue,
+  };
+}

--- a/src/screens/applications/ApplicationHistoryCard.tsx
+++ b/src/screens/applications/ApplicationHistoryCard.tsx
@@ -3,14 +3,17 @@ import {Image, StyleSheet, TouchableOpacity, View} from 'react-native';
 import {Text} from '../../components/common/Text';
 import CalendarIcon from '../../assets/icons/eventCalendarIcon.svg';
 import LocationIcon from '../../assets/icons/eventLocationIcon.svg';
-import {ApplicationHistory, ApplicationStatus} from './types';
+import {ApplicationSummary, ApplicationStatusLabel} from './types';
 
 type ApplicationHistoryCardProps = {
-  application: ApplicationHistory;
+  application: ApplicationSummary;
   onPress?: () => void;
 };
 
-const STATUS_THEME: Record<ApplicationStatus, {background: string; text: string}> = {
+const STATUS_THEME: Record<
+  ApplicationStatusLabel,
+  {background: string; text: string}
+> = {
   진행중: {
     background: '#FEE2E2',
     text: '#B91C1C',
@@ -39,11 +42,19 @@ export function ApplicationHistoryCard({
       accessibilityRole="button"
       accessibilityLabel={`${application.title} 신청 내역`}>
       <View style={styles.row}>
-        <Image
-          source={{uri: application.imageUrl}}
-          style={styles.thumbnail}
-          resizeMode="cover"
-        />
+        {application.thumbnailUrl ? (
+          <Image
+            source={{uri: application.thumbnailUrl}}
+            style={styles.thumbnail}
+            resizeMode="cover"
+          />
+        ) : (
+          <View style={[styles.thumbnail, styles.thumbnailPlaceholder]}>
+            <Text variant="headlineS" color="#FFFFFF" align="center">
+              {application.title.slice(0, 1)}
+            </Text>
+          </View>
+        )}
 
         <View style={styles.content}>
           <View style={styles.headerRow}>
@@ -92,15 +103,17 @@ export function ApplicationHistoryCard({
               </Text>
             </View>
 
-            <View style={[styles.metaRow, styles.metaRowSpacing]}>
-              <View style={styles.metaIcon} />
-              <Text
-                variant="bodyM"
-                color="#9CA3AF"
-                style={[styles.metaText, styles.address]}>
-                {application.address}
-              </Text>
-            </View>
+            {application.address ? (
+              <View style={[styles.metaRow, styles.metaRowSpacing]}>
+                <View style={styles.metaIcon} />
+                <Text
+                  variant="bodyM"
+                  color="#9CA3AF"
+                  style={[styles.metaText, styles.address]}>
+                  {application.address}
+                </Text>
+              </View>
+            ) : null}
           </View>
         </View>
       </View>
@@ -128,6 +141,11 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     backgroundColor: '#E5E7EB',
     marginRight: 16,
+  },
+  thumbnailPlaceholder: {
+    backgroundColor: '#06B0B7',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   content: {
     flex: 1,

--- a/src/screens/applications/ApplicationListScreen.tsx
+++ b/src/screens/applications/ApplicationListScreen.tsx
@@ -1,109 +1,22 @@
 import React from 'react';
-import {FlatList, ListRenderItemInfo, StyleSheet, View} from 'react-native';
+import {
+  ActivityIndicator,
+  FlatList,
+  ListRenderItemInfo,
+  RefreshControl,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import DetailHeader from '../../components/common/DetailHeader';
 import {ApplicationHistoryCard} from './ApplicationHistoryCard';
-import {ApplicationHistory} from './types';
+import {ApplicationSummary} from './types';
 import {useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {ApplicationsStackParamList} from '../../app/navigation/types';
-
-const baseGuide = [
-  '깨끗한 옷을 행사장으로 들고옵니다.',
-  '행사장 입구에서 가져온 옷을 QR 로 등록합니다.',
-  '등록 후 교환 티켓이 잘 들어왔는지 확인합니다.',
-  '교환 티켓 만큼 행사장에 있는 옷들을 고릅니다.',
-  '교환 존에서 담당자에게 QR 제시 후 수령합니다.',
-];
-
-const basePrecautions = [
-  '가져온 옷은 반드시 세탁 필수!',
-  '행사장 내에서 음식물 섭취는 제한될 수 있습니다.',
-];
-
-const applications: ApplicationHistory[] = [
-  {
-    id: 'application-1',
-    title: '👕아름다운X수선혁명랩(Lab)',
-    description:
-      `'교환'과 '수선'으로 끝까지 입는 경험과 실천을 제공하는 지속 가능한 의생활 실험 공간`,
-    status: '진행중',
-    startDate: '2025년 09월 02일',
-    endDate: '09월 20일',
-    location: '서울 중구 왕십리로 63 언더스탠드에비뉴',
-    address: '서울 성동구 왕십리로 63 언더스탠드에비뉴',
-    imageUrl:
-      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=256&h=256&fit=crop',
-    usageGuide: baseGuide,
-    precautions: basePrecautions,
-    optionTrail: [
-      {eventOptionId: 1, name: '9월 2일', type: 'DATE'},
-      {eventOptionId: 2, name: '오전 세션', type: 'TIME'},
-    ],
-    qrToken: 'APPLICATION_TOKEN_1',
-    expiresInSeconds: 1800,
-  },
-  {
-    id: 'application-2',
-    title: '전국 수선 자랑 공모전 3탄',
-    description: '당신의 수선 이야기를 들려주세요',
-    status: '진행중',
-    startDate: '2025년 09월 08일',
-    endDate: '10월 01일',
-    location: '아름다운수선혁명 Lab',
-    address: '서울 성동구 뚝섬로 273',
-    imageUrl:
-      'https://images.unsplash.com/photo-1475180098004-ca77a66827be?w=256&h=256&fit=crop',
-    usageGuide: baseGuide,
-    precautions: basePrecautions,
-    optionTrail: [
-      {eventOptionId: 3, name: '9월 8일', type: 'DATE'},
-      {eventOptionId: 4, name: '오후 세션', type: 'TIME'},
-    ],
-    qrToken: 'APPLICATION_TOKEN_2',
-    expiresInSeconds: 1200,
-  },
-  {
-    id: 'application-3',
-    title: '대한민국 순환경제 페스티벌',
-    description: '의생활 속 제로웨이스트 실천 이벤트',
-    status: '종료',
-    startDate: '2025년 07월 02일',
-    endDate: '07월 03일',
-    location: '코엑스 마곡',
-    address: '서울특별시 강남구 영동대로 513',
-    imageUrl:
-      'https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=256&h=256&fit=crop',
-    usageGuide: baseGuide,
-    precautions: basePrecautions,
-    optionTrail: [
-      {eventOptionId: 5, name: '7월 2일', type: 'DATE'},
-      {eventOptionId: 6, name: '하루권', type: 'PASS'},
-    ],
-    qrToken: 'APPLICATION_TOKEN_3',
-    expiresInSeconds: 0,
-  },
-  {
-    id: 'application-4',
-    title: '21%파티',
-    description: '의생활 속 제로웨이스트 실천 이벤트',
-    status: '종료',
-    startDate: '2023년 06월 06일',
-    endDate: '06월 06일',
-    location: '헤이그라운드 성수 시작점',
-    address: '서울 성동구 왕십리로 2길 20',
-    imageUrl:
-      'https://images.unsplash.com/photo-1475274228244-1645d8304a5e?w=256&h=256&fit=crop',
-    usageGuide: baseGuide,
-    precautions: basePrecautions,
-    optionTrail: [
-      {eventOptionId: 7, name: '6월 6일', type: 'DATE'},
-      {eventOptionId: 8, name: '저녁 파티', type: 'SESSION'},
-    ],
-    qrToken: 'APPLICATION_TOKEN_4',
-    expiresInSeconds: 600,
-  },
-];
+import {Text} from '../../components/common/Text';
+import {useApplicationsList} from '../../hooks/useApplications';
 
 type NavigationProp = NativeStackNavigationProp<
   ApplicationsStackParamList,
@@ -112,32 +25,99 @@ type NavigationProp = NativeStackNavigationProp<
 
 export default function ApplicationListScreen() {
   const navigation = useNavigation<NavigationProp>();
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isRefetching,
+  } = useApplicationsList();
 
-  const handlePressItem = (item: ApplicationHistory) => {
-    navigation.navigate('ApplicationDetail', {application: item});
+  const applications =
+    data?.pages.flatMap(page => page.items as ApplicationSummary[]) ?? [];
+
+  const handlePressItem = (item: ApplicationSummary) => {
+    navigation.navigate('ApplicationDetail', {
+      applicationId: item.id,
+      initialData: item,
+    });
   };
 
   const renderApplicationItem = ({
     item,
-  }: ListRenderItemInfo<ApplicationHistory>) => (
+  }: ListRenderItemInfo<ApplicationSummary>) => (
     <ApplicationHistoryCard
       application={item}
       onPress={() => handlePressItem(item)}
     />
   );
 
+  const handleLoadMore = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  const renderFooter = () => {
+    if (!isFetchingNextPage) {
+      return null;
+    }
+    return (
+      <View style={styles.footer}>
+        <ActivityIndicator size="small" color="#6B7280" />
+      </View>
+    );
+  };
+
+  const renderStateView = (
+    message: string,
+    showRetry?: boolean,
+  ) => (
+    <View style={styles.stateContainer}>
+      <Text variant="bodyM" color="#6B7280" style={styles.stateText}>
+        {message}
+      </Text>
+      {showRetry ? (
+        <TouchableOpacity style={styles.retryButton} onPress={() => refetch()}>
+          <Text variant="labelM" color="#FFFFFF">
+            다시 시도
+          </Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
       <DetailHeader title="신청 내역" useTopInset />
       <View style={styles.container}>
-        <FlatList
-          data={applications}
-          renderItem={renderApplicationItem}
-          keyExtractor={item => item.id}
-          contentContainerStyle={styles.listContent}
-          ItemSeparatorComponent={() => <View style={styles.separator} />}
-          showsVerticalScrollIndicator={false}
-        />
+        {isLoading && applications.length === 0 ? (
+          <View style={styles.stateContainer}>
+            <ActivityIndicator size="large" color="#6B7280" />
+          </View>
+        ) : isError && applications.length === 0 ? (
+          renderStateView('신청 내역을 불러오지 못했습니다.', true)
+        ) : applications.length === 0 ? (
+          renderStateView('아직 신청 내역이 없습니다.')
+        ) : (
+          <FlatList
+            data={applications}
+            renderItem={renderApplicationItem}
+            keyExtractor={item => item.id}
+            contentContainerStyle={styles.listContent}
+            ItemSeparatorComponent={() => <View style={styles.separator} />}
+            showsVerticalScrollIndicator={false}
+            onEndReached={handleLoadMore}
+            onEndReachedThreshold={0.8}
+            ListFooterComponent={renderFooter}
+            refreshControl={
+              <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
+            }
+          />
+        )}
       </View>
     </SafeAreaView>
   );
@@ -159,5 +139,24 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: 16,
+  },
+  footer: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  stateContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
+  stateText: {
+    marginBottom: 16,
+  },
+  retryButton: {
+    backgroundColor: '#06B0B7',
+    borderRadius: 999,
+    paddingHorizontal: 24,
+    paddingVertical: 10,
   },
 });

--- a/src/screens/applications/types.ts
+++ b/src/screens/applications/types.ts
@@ -1,22 +1,26 @@
-export type ApplicationStatus = '진행중' | '종료' | '예정';
+export type ApplicationStatusLabel = '진행중' | '종료' | '예정';
 
-export type ApplicationHistory = {
+export type ApplicationSummary = {
   id: string;
+  eventId: string;
   title: string;
   description: string;
-  status: ApplicationStatus;
+  status: ApplicationStatusLabel;
   startDate: string;
   endDate: string;
   location: string;
-  address: string;
-  imageUrl: string;
+  address?: string;
+  thumbnailUrl?: string;
+};
+
+export type ApplicationOption = {
+  eventOptionId: number;
+  name: string;
+  type: string;
+};
+
+export type ApplicationDetail = ApplicationSummary & {
   usageGuide: string[];
   precautions: string[];
-  optionTrail: Array<{
-    eventOptionId: number;
-    name: string;
-    type: string;
-  }>;
-  qrToken: string;
-  expiresInSeconds: number;
+  optionTrail: ApplicationOption[];
 };


### PR DESCRIPTION
### 🔧 작업 내용
- 신청 내역 목록/상세 API와 QR 발급 API를 연동하고 React Query 훅(`useApplicationsList`, `useApplicationDetail`, `useApplicationQr`)을 추가했습니다.
- 목록/상세 화면이 실제 데이터(로딩, 빈 상태, 에러/재시도, 무한 스크롤)를 사용하도록 업데이트했으며, QR 타이머·재발급 및 모달 확대 기능을 구현했습니다.
- QueryClientProvider를 앱 루트에 적용해 React Query가 전역으로 동작하도록 했습니다.
- `useApplicationDetail`이 전달받은 요약 데이터를 `placeholderData`로 이용하도록 수정해 상세 API가 항상 호출되도록 보완했습니다.
- `Results.md`에 상세 API 호출 문제 원인과 해결 과정을 기록했습니다.

### ✅ 테스트
- Android 에뮬레이터에서 ApplicationList → ApplicationDetail 플로우 및 QR 발급/모달 동작 수동 확인
- 신청 상세 화면 진입 시 네트워크 패널에서 `GET /events/applications/:id` 호출 여부 수동 확인
- `npm start` 로컬 실행

### 🔗 관련 이슈
- closes #60

### 📸 스크린샷
- UI 변경 없음