### PR TITLE
#102 키워드 불러오는 API 구현

### DIFF
--- a/src/api/communityApi.ts
+++ b/src/api/communityApi.ts
@@ -242,3 +242,14 @@ export async function updateCommunityPost(
 ): Promise<void> {
   await apiClient.put(`/community/posts/${postId}`, data);
 }
+
+interface PostKeywordsResponse {
+  keywords: string[];
+}
+
+export async function getPostKeywords(): Promise<string[]> {
+  const response = await apiClient.get<PostKeywordsResponse>(
+    '/community/posts/keywords',
+  );
+  return response.data?.keywords ?? [];
+}

--- a/src/screens/community/PostEditScreen.tsx
+++ b/src/screens/community/PostEditScreen.tsx
@@ -26,6 +26,7 @@ import {
   updateCommunityPost,
   getCommunityPostDetail,
   CommunityPostDetail,
+  getPostKeywords,
 } from '../../api/communityApi';
 
 type PostEditParamList = {
@@ -61,12 +62,26 @@ export default function PostEditScreen() {
   const [endCursor, setEndCursor] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [keywords, setKeywords] = useState<string[]>([]);
 
   const titleInputRef = useRef<TextInput>(null);
   const contentInputRef = useRef<TextInput>(null);
   const scrollViewRef = useRef<ScrollView>(null);
 
-  const keywords: string[] = ['후기', '수선', '질문', '기타'];
+  useEffect(() => {
+    const fetchKeywords = async () => {
+      try {
+        const keywordsList = await getPostKeywords();
+        setKeywords(keywordsList);
+      } catch (error) {
+        console.error('Failed to fetch keywords:', error);
+        // 기본값으로 폴백
+        setKeywords(['후기', '수선', '질문', '기타']);
+      }
+    };
+
+    fetchKeywords();
+  }, []);
 
   useEffect(() => {
     const fetchPostData = async () => {
@@ -679,4 +694,3 @@ const styles = StyleSheet.create({
     height: '100%',
   },
 });
-

--- a/src/screens/community/PostRegisterScreen.tsx
+++ b/src/screens/community/PostRegisterScreen.tsx
@@ -24,6 +24,7 @@ import PlusIcon from '../../assets/icons/plus.svg';
 import {
   uploadCommunityImage,
   createCommunityPost,
+  getPostKeywords,
 } from '../../api/communityApi';
 
 interface PhotoNode {
@@ -40,19 +41,33 @@ export default function PostRegisterScreen() {
   const insets = useSafeAreaInsets();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [selectedKeyword, setSelectedKeyword] = useState<KeywordType>(null);
+  const [selectedKeyword, setSelectedKeyword] = useState<string | null>(null);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [showGalleryModal, setShowGalleryModal] = useState(false);
   const [photos, setPhotos] = useState<PhotoNode[]>([]);
   const [hasNextPage, setHasNextPage] = useState(true);
   const [endCursor, setEndCursor] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [keywords, setKeywords] = useState<string[]>([]);
 
   const titleInputRef = useRef<TextInput>(null);
   const contentInputRef = useRef<TextInput>(null);
   const scrollViewRef = useRef<ScrollView>(null);
 
-  const keywords: string[] = ['후기', '수선', '질문', '기타'];
+  useEffect(() => {
+    const fetchKeywords = async () => {
+      try {
+        const keywordsList = await getPostKeywords();
+        setKeywords(keywordsList);
+      } catch (error) {
+        console.error('Failed to fetch keywords:', error);
+        // 기본값으로 폴백
+        setKeywords(['후기', '수선', '질문', '기타']);
+      }
+    };
+
+    fetchKeywords();
+  }, []);
 
   const requestPermissions = async (): Promise<boolean> => {
     if (Platform.OS === 'android') {
@@ -151,7 +166,7 @@ export default function PostRegisterScreen() {
     if (selectedKeyword === keyword) {
       setSelectedKeyword(null);
     } else {
-      setSelectedKeyword(keyword as KeywordType);
+      setSelectedKeyword(keyword);
     }
   };
 


### PR DESCRIPTION
# Pull Request

# [Feat] 게시물 키워드 목록 API 연동

## 📌 작업 내용
- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링

## 🔎 상세 내용

### 1. 게시물 키워드 목록 API 연동
- 게시물 키워드 목록 조회 API(`GET /community/posts/keywords`) 연결
- 하드코딩된 키워드 배열을 API 호출로 대체
- `PostRegisterScreen`과 `PostEditScreen`에서 동적으로 키워드 목록 로드
- API 호출 실패 시 기본값으로 폴백하여 안정성 확보

### 2. API 응답 구조 반영
- `PostKeywordsResponse` 인터페이스 추가
- 서버 응답 구조 `{ "keywords": [...] }`에 맞게 파싱 로직 구현
- `response.data?.keywords ?? []`로 안전하게 키워드 배열 추출

### 3. 에러 처리
- API 호출 실패 시 콘솔에 에러 로그 출력
- 기본값(`['후기', '수선', '질문', '기타']`)으로 폴백하여 사용자 경험 유지
- 앱 크래시 방지

## 🧠 진행 이유

### 동적 키워드 관리
- 하드코딩된 키워드 배열을 제거하고 서버에서 관리하도록 변경
- 키워드 추가/수정/삭제 시 앱 업데이트 없이 서버 설정만으로 반영 가능
- 관리자나 백엔드에서 키워드를 유연하게 관리할 수 있음

### 일관성 유지
- 게시물 등록 화면과 수정 화면 모두 동일한 API를 사용하여 키워드 목록 일관성 보장
- 서버와 클라이언트 간 데이터 동기화

### 사용자 경험 개선
- API 호출 실패 시에도 기본값으로 폴백하여 기능 사용 가능
- 네트워크 오류나 서버 문제가 있어도 앱이 정상 동작

## ✅ 체크리스트
- [x] 단위 테스트 통과
- [x] 코드 컨벤션 준수
- [ ] 관련 문서 업데이트

## 변경된 파일

### API
- `src/api/communityApi.ts`
  - `PostKeywordsResponse` 인터페이스 추가
  - `getPostKeywords()` 함수 추가
 t
  interface PostKeywordsResponse {
    keywords: string[];
  }

  export async function getPostKeywords(): Promise<string[]> {
    const response = await apiClient.get<PostKeywordsResponse>(
      '/community/posts/keywords',
    );
    return response.data?.keywords ?? [];
  }
  ### Screens
- `src/screens/community/PostRegisterScreen.tsx`
  - 하드코딩된 `keywords` 배열을 `useState`로 변경
  - `useEffect`에서 `getPostKeywords()` 호출하여 키워드 목록 로드
  - API 호출 실패 시 기본값으로 폴백
  - `KeywordType` 타입 오류 수정 (`string | null`로 변경)

- `src/screens/community/PostEditScreen.tsx`
  - 하드코딩된 `keywords` 배열을 `useState`로 변경
  - `useEffect`에서 `getPostKeywords()` 호출하여 키워드 목록 로드
  - API 호출 실패 시 기본값으로 폴백

## API 스펙

### 게시물 키워드 목록 조회
- **Method**: `GET`
- **Path**: `/community/posts/keywords`
- **Response**:
{
  "keywords": [
    "질문",
    "리뷰",
    "수선"
  ]
}## 테스트 시나리오
1. ✅ 게시물 등록 화면 진입 시 키워드 목록이 API에서 로드됨
2. ✅ 게시물 수정 화면 진입 시 키워드 목록이 API에서 로드됨
3. ✅ API 호출 실패 시 기본값으로 폴백되어 기능 정상 동작
4. ✅ 서버에서 반환한 키워드 목록이 화면에 정상 표시됨

연결된 이슈
close #

연결된 이슈
close #
