### PR TITLE
#116 상태 라벨 통일 및 랭킹 타입/알림 개선

### DIFF
--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -10,7 +10,7 @@ import {
   CancelEventApplicationRequest,
 } from '../api/events/events';
 
-export type EventStatusLabel = '예정' | '모집중' | '마감';
+export type EventStatusLabel = '예정' | '진행' | '마감';
 
 export type EventSummary = {
   id: string;
@@ -74,7 +74,7 @@ function mapStatus(status: string): EventStatusLabel {
     case 'APPROVAL':
       return '예정';
     case 'OPEN':
-      return '모집중';
+      return '진행';
     case 'CLOSED':
       return '마감';
     default:

--- a/src/screens/applications/ApplicationDetailScreen.tsx
+++ b/src/screens/applications/ApplicationDetailScreen.tsx
@@ -70,7 +70,7 @@ export default function ApplicationDetailScreen() {
       : '--:--';
 
   const isCancelable = React.useMemo(() => {
-    const isEventOpen = eventStatusCode === 'OPEN' || eventStatusCode === 'RUNNING';
+    const isEventOpen = eventStatusCode === 'OPEN' || eventStatusCode === 'APPROVAL';
     return isEventOpen && isApplied;
   }, [eventStatusCode, isApplied]);
 
@@ -83,6 +83,9 @@ export default function ApplicationDetailScreen() {
   const handleCloseModal = () => setShowModal(false);
 
   const handleCancelApplication = (reason: string) => {
+    if (!data) {
+      return;
+    }
     cancelApplication(
       {
         applicationId,
@@ -428,7 +431,7 @@ function resolveStatuses(
 
   const isApplied =
     applicationStatusCode === 'APPLIED' ||
-    (!applicationStatusCode && statusLabel === '진행중');
+    (!applicationStatusCode && statusLabel === '진행');
 
   return {
     eventStatusCode,

--- a/src/screens/applications/ApplicationHistoryCard.tsx
+++ b/src/screens/applications/ApplicationHistoryCard.tsx
@@ -14,7 +14,7 @@ const STATUS_THEME: Record<
   ApplicationStatusLabel,
   {background: string; text: string}
 > = {
-  진행중: {
+  진행: {
     background: '#FEE2E2',
     text: '#B91C1C',
   },
@@ -32,7 +32,11 @@ export function ApplicationHistoryCard({
   application,
   onPress,
 }: ApplicationHistoryCardProps) {
-  const theme = STATUS_THEME[application.status];
+  const displayStatus: ApplicationStatusLabel = 
+    application.applicationStatusCode?.toUpperCase() === 'APPROVAL' 
+      ? '예정' 
+      : application.status;
+  const theme = STATUS_THEME[displayStatus];
 
   return (
     <TouchableOpacity
@@ -71,7 +75,7 @@ export function ApplicationHistoryCard({
                 {backgroundColor: theme.background},
               ]}>
               <Text variant="bodyS" color={theme.text} style={styles.statusText}>
-                {application.status}
+                {displayStatus}
               </Text>
             </View>
           </View>

--- a/src/screens/applications/types.ts
+++ b/src/screens/applications/types.ts
@@ -1,4 +1,4 @@
-export type ApplicationStatusLabel = '진행중' | '종료' | '예정';
+export type ApplicationStatusLabel = '진행' | '종료' | '예정';
 
 export type ApplicationSummary = {
   id: string;

--- a/src/screens/event/EventCard.tsx
+++ b/src/screens/event/EventCard.tsx
@@ -15,7 +15,7 @@ interface EventCardProps {
   startDate: string;
   endDate: string;
   location: string;
-  status: '예정' | '모집중' | '마감';
+  status: '예정' | '진행' | '마감';
   imageUrl?: string;
   imageSource?: any;
   onPress?: () => void;
@@ -36,7 +36,7 @@ export function EventCard({
     switch (status) {
       case '예정':
         return '#9333EA';
-      case '모집중':
+      case '진행':
         return '#FF4242';
       case '마감':
         return '#6b7280';

--- a/src/screens/event/EventDetailScreen.tsx
+++ b/src/screens/event/EventDetailScreen.tsx
@@ -110,14 +110,11 @@ export default function EventDetailScreen() {
   );
 
   const isActionPending = applyEventMutation.isPending;
-  const isEventOpen = event.status === '모집중';
+  const isEventOpen = event.status === '진행' || event.status === '예정';
   const isApplyDisabled = !isEventOpen;
 
   const getButtonText = () => {
     if (!isEventOpen) {
-      if (event.status === '예정') {
-        return '신청 예정';
-      }
       return '신청 마감';
     }
     return '신청하기';

--- a/src/screens/event/EventScreen.tsx
+++ b/src/screens/event/EventScreen.tsx
@@ -18,7 +18,7 @@ type FilterType = 'all' | 'APPROVAL' | 'OPEN' | 'CLOSED';
 const FILTER_OPTIONS: Array<{value: FilterType; label: string}> = [
   {value: 'all', label: '전체'},
   {value: 'APPROVAL', label: '예정'},
-  {value: 'OPEN', label: '모집중'},
+  {value: 'OPEN', label: '진행'},
   {value: 'CLOSED', label: '마감'},
 ];
 
@@ -65,10 +65,10 @@ export default function EventScreen() {
     }
   };
 
-  // 상태별 정렬 우선순위: 모집중 > 예정 > 마감
+  // 상태별 정렬 우선순위: 진행 > 예정 > 마감
   const getStatusPriority = (status: string): number => {
     switch (status) {
-      case '모집중':
+      case '진행':
         return 1;
       case '예정':
         return 2;

--- a/src/screens/store/product/ProductDetailScreen.tsx
+++ b/src/screens/store/product/ProductDetailScreen.tsx
@@ -60,6 +60,7 @@ export default function ProductDetailScreen() {
       },
       {
         onSuccess: () => {
+          Alert.alert('신청 완료', '교환 신청이 완료되었습니다.');
           setIsModalVisible(false);
         },
         onError: (error: any) => {

--- a/src/types/ranking.ts
+++ b/src/types/ranking.ts
@@ -28,3 +28,17 @@ export interface RankingResponse {
   rankings: RankingUser[];
 }
 
+// API 응답 타입
+export interface RankUser {
+  rank: number;
+  nickname: string;
+  repairCount: number;
+  rankChange: number;
+}
+
+export interface RankingApiResponse {
+  comparedSnapshotDate: string;
+  topRanks: RankUser[];
+  me: RankUser | null; // 로그인하지 않은 경우 null
+}
+


### PR DESCRIPTION
# Pull Request

### 📝 작업내용

- 이벤트/신청 상태 라벨 통일 (`모집중/진행중` → `진행`)
- 이벤트 상세/목록 화면에서 상태 코드(`APPROVAL`, `OPEN`, `CLOSED`) 매핑 로직 정리
- 신청 상세/내역 화면에서 `APPROVAL` 상태를 `예정`으로 노출하도록 변경
- 랭킹 API 타입 분리 및 비로그인 사용자(`me === null`) 대응 로직 추가
- 교환 신청 완료 시 알림 팝업 추가
- React Query 훅(`useApplications`, `useEvents`) 타입 보강 및 에러 처리 안전성 개선

연결된 이슈
close #116
